### PR TITLE
Adding new argument to specify account IDs as csv file

### DIFF
--- a/policy_migration_scripts/utils/validation.py
+++ b/policy_migration_scripts/utils/validation.py
@@ -3,9 +3,9 @@
 
 from botocore.exceptions import ClientError
 
-from policy_migration_scripts.utils.constants import ACCOUNT_ID_LENGTH
 from policy_migration_scripts.utils.log import get_logger
 from policy_migration_scripts.utils.model import ValidationException
+from policy_migration_scripts.utils.utils import is_valid_account_id
 
 LOGGER = get_logger(__name__)
 
@@ -30,10 +30,6 @@ def rollback_args_deep_validate(args_, payer_account_, all_member_accounts_):
         validate_org_accounts(args_["accounts"], payer_account_, all_member_accounts_)
     if args_["excluded_accounts"]:
         validate_org_accounts(args_["excluded_accounts"], payer_account_, all_member_accounts_)
-
-
-def is_valid_account_id(account_id):
-    return account_id.isnumeric() and len(account_id) == ACCOUNT_ID_LENGTH
 
 
 def _validate_account(account_id):


### PR DESCRIPTION


*Description of changes:*
* Adding a new argument `--accounts-file` to pass account IDs as CSV file
* CSV file should have no headers and list all the 12 digit AWS account IDs in the first column of the file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
