### PR TITLE
BugFix: Correcting service prefix for UpdatePurchaseOrderStatus action

### DIFF
--- a/policy_migration_scripts/config/action_mapping_config.json
+++ b/policy_migration_scripts/config/action_mapping_config.json
@@ -128,6 +128,6 @@
         "purchase-orders:AddPurchaseOrder",
         "purchase-orders:DeletePurchaseOrder",
         "purchase-orders:UpdatePurchaseOrder",
-        "invoicing:UpdatePurchaseOrderStatus"
+        "purchase-orders:UpdatePurchaseOrderStatus"
     ]
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/bulk-policy-migrator-scripts-for-account-cost-billing-consoles/issues/11

*Description of changes:*
* Fixing service prefix for `UpdatePurchaseOrderStatus` action. Correct action is `purchase-orders:UpdatePurchaseOrderStatus` and not `invoicing:UpdatePurchaseOrderStatus`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
